### PR TITLE
remove accentuated characters (may bother pip commands)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - {{ compiler('cxx')}}
     - make                               # [unix]
     - pkg-config                         # [linux]
-    - {{ cdt('mesa-libgl-devel') }}      # [linux]
+    - {{ cdt('mesa-libgl-devel') }}      # [linux]  # match libqglviewer CDT GL strategy
     # from https://conda-forge.org/docs/maintainer/knowledge_base.html#libgl
     - python                             # [build_platform != target_platform]
     - sip                                # [build_platform != target_platform]
@@ -47,8 +47,8 @@ requirements:
 
   run:
     - python
-    - {{ pin_compatible('pyqt',               max_pin='x.x') }} 
-    - {{ pin_compatible('libqglviewer',       max_pin='x.x') }} 
+    - {{ pin_compatible('pyqt', max_pin='x.x') }}
+    - {{ pin_compatible('libqglviewer', max_pin='x.x') }}
     - pyopengl
     - xorg-libxfixes  # [linux]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version = "1.3.3.dev"
 description = "Python bindings of libQGLViewer."
 readme = "README.md"
 authors = [
-    { name = "Frédéric Boudon", email = "frederic.boudon@cirad.fr" }
+    { name = "Frederic Boudon", email = "frederic.boudon@cirad.fr" }
 ]
 
 [tool.sip.project]


### PR DESCRIPTION
add comment for remembering why cdt libGL has been choosen over libgl on linux